### PR TITLE
Pin cosign-installer to v3.10.0

### DIFF
--- a/.github/workflows/artifacts.yaml
+++ b/.github/workflows/artifacts.yaml
@@ -55,7 +55,7 @@ jobs:
         uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
 
       - name: Set up Cosign
-        uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
+        uses: sigstore/cosign-installer@d7543c93d881b35a8faa02e8e3605f69b7a1ce62 # v3.10.0
         if: ${{ inputs.publish }}
 
       - name: Set image name

--- a/renovate.json
+++ b/renovate.json
@@ -49,6 +49,13 @@
       "allowedVersions": "/^v[0-9]+\\.[0-9]+\\.[0-9]+(\\.[0-9]+)?$/"
     },
     {
+      "description": "Pin cosign-installer",
+      "matchPackageNames": [
+        "sigstore/cosign-installer"
+      ],
+      "enabled": false
+    },
+    {
       "matchUpdateTypes": [
         "minor"
       ],


### PR DESCRIPTION
Demote `sigstore/cosign-installer` from v4.1.2 back to v3.10.0 (`d7543c9`) and add a Renovate rule so it stays pinned (otherwise Renovate re-bumps it to v4).

- `.github/workflows/artifacts.yaml`: cosign-installer → v3.10.0
- `renovate.json`: disable updates for `sigstore/cosign-installer`

## Test plan
- [x] Renovate no longer lists cosign-installer as an update
- [x] Image signing/verification still works on the next publish